### PR TITLE
Default gzip compression level to gzip.BestSpeed instead of gzip.NoCompression.

### DIFF
--- a/compression.go
+++ b/compression.go
@@ -3,6 +3,7 @@ package extsort
 import (
 	"compress/gzip"
 	"io"
+	"io/ioutil"
 )
 
 // Compression codec.
@@ -32,7 +33,8 @@ func (c Compression) newReader(r io.Reader) (io.ReadCloser, error) {
 func (c Compression) newWriter() compressedWriter {
 	switch c {
 	case CompressionGzip:
-		return new(gzip.Writer)
+		wr, _ := gzip.NewWriterLevel(ioutil.Discard, gzip.BestSpeed)
+		return wr
 	}
 	return new(plainWriter)
 }


### PR DESCRIPTION
Nice library. This PR fixes what I believe is a bug where the way the gzip writer was initialized resulted in the compression level being set to NoCompression with no way (that I could find) to override the compression level. As part of the fix I figured BestSpeed was the most useful compression level given that performance of the external sort would be a priority.