### PR TITLE
Use entry pool for memBuffer

### DIFF
--- a/extsort.go
+++ b/extsort.go
@@ -81,7 +81,7 @@ func (s *Sorter) flush() error {
 			lastKey = append(lastKey[:0], key...)
 		}
 
-		if err := s.tw.Encode(&ent); err != nil {
+		if err := s.tw.Encode(ent); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
In one of my benchmarks that uses extsort, I was getting higher memory use than expected. I believe what was happening in the existing version is that the extra growth when appending to entry.data in memBuffer is large due to some key/vals, and that survives across all flushes until all of the entry.data are large. Using the pool lets it shrink back down with GC cycles.

In my benchmarks the heap profile (when taken at differing times in the middle of Appends) shows a 5X reduction of in-use memory at/below Append. 

If I remember correctly you are particular of the changes that go in 😉 so I didn't want to make too extensive of a change if you had some guidance for me.