### PR TITLE
Support snappy compression

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.15
 require (
 	github.com/bsm/ginkgo v1.16.0
 	github.com/bsm/gomega v1.11.0
+	github.com/golang/snappy v0.0.4
 )

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ github.com/bsm/ginkgo v1.16.0 h1:d0FSr//fhUpdWr4uBHBLG+xN1bOYWERSBnfu1hGknfU=
 github.com/bsm/ginkgo v1.16.0/go.mod h1:RabIZLzOCPghgHJKUqHZpqrQETA5AnF4aCSIYy5C1bk=
 github.com/bsm/gomega v1.11.0 h1:wg9DVGPETNZLIbMsseneMV1a7uo/x+wsCyNXdEcifDI=
 github.com/bsm/gomega v1.11.0/go.mod h1:JifAceMQ4crZIWYUKrlGcmbN3bqHogVTADMD2ATsbwk=
+github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
+github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=


### PR DESCRIPTION
Benchmark goes from about 2056 ns/op for gzip to about 911.3 ns/op on my box.