### PR TITLE
Keep last item when deduplicating

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -36,7 +36,7 @@ func Example_map() {
 	}
 
 	// Output:
-	// bar v2
+	// bar v4
 	// baz v3
 	// dau v5
 	// foo v1

--- a/extsort.go
+++ b/extsort.go
@@ -78,7 +78,7 @@ func (s *Sorter) flush() error {
 			if lastKey != nil && s.opt.Dedupe(key, lastKey) {
 				continue
 			}
-			lastKey = append(lastKey[:0], key...)
+			lastKey = key
 		}
 
 		if err := s.tw.Encode(ent); err != nil {

--- a/extsort.go
+++ b/extsort.go
@@ -10,7 +10,7 @@ type Sorter struct {
 // New inits a sorter
 func New(opt *Options) *Sorter {
 	opt = opt.norm()
-	return &Sorter{opt: opt, buf: &memBuffer{less: opt.Less}}
+	return &Sorter{opt: opt, buf: &memBuffer{compare: opt.Compare}}
 }
 
 // Append appends a data chunk to the sorter.
@@ -81,7 +81,7 @@ func (s *Sorter) flush() error {
 			lastKey = key
 		}
 
-		if err := s.tw.Encode(ent); err != nil {
+		if err := s.tw.Encode(ent.entry); err != nil {
 			return err
 		}
 	}
@@ -112,7 +112,7 @@ func newIterator(name string, offsets []int64, opt *Options) (*Iterator, error) 
 		return nil, err
 	}
 
-	iter := &Iterator{tr: tr, heap: &minHeap{less: opt.Less}, dedupe: opt.Dedupe}
+	iter := &Iterator{tr: tr, heap: &minHeap{compare: opt.Compare}, dedupe: opt.Dedupe}
 	for i := 0; i < tr.NumSections(); i++ {
 		if err := iter.fillHeap(i); err != nil {
 			_ = tr.Close()

--- a/extsort_test.go
+++ b/extsort_test.go
@@ -130,6 +130,7 @@ var _ = Describe("Sorter", func() {
 			BufferSize: 64 * 1024,
 			Dedupe:     bytes.Equal,
 			WorkDir:    workDir,
+			Sort:       sort.Stable,
 		})
 		defer deduped.Close()
 

--- a/extsort_test.go
+++ b/extsort_test.go
@@ -99,12 +99,12 @@ var _ = Describe("Sorter", func() {
 		Expect(subject.Put([]byte("dau"), []byte("v5"))).To(Succeed())
 		Expect(subject.Put([]byte("bar"), []byte("v6"))).To(Succeed())
 		Expect(drain(subject)).To(Equal([][2]string{
-			{"bar", "v2"},
 			{"bar", "v6"},
+			{"bar", "v2"},
 			{"baz", "v3"},
 			{"dau", "v5"},
-			{"foo", "v1"},
 			{"foo", "v4"},
+			{"foo", "v1"},
 		}))
 	})
 
@@ -135,7 +135,7 @@ var _ = Describe("Sorter", func() {
 		defer deduped.Close()
 
 		for i := 0; i < 100_000; i++ {
-			val := []byte(fmt.Sprintf("x%d", i%10))
+			val := []byte(fmt.Sprintf("x%d", i))
 			Expect(deduped.Put([]byte("foo"), val)).To(Succeed())
 			Expect(deduped.Put([]byte("baz"), val)).To(Succeed())
 		}
@@ -143,9 +143,9 @@ var _ = Describe("Sorter", func() {
 		Expect(deduped.Put([]byte("dau"), []byte("v2"))).To(Succeed())
 		Expect(drain(deduped)).To(Equal([][2]string{
 			{"bar", "v1"},
-			{"baz", "x4"},
+			{"baz", "x99999"},
 			{"dau", "v2"},
-			{"foo", "x9"},
+			{"foo", "x99999"},
 		}))
 	})
 

--- a/options.go
+++ b/options.go
@@ -5,14 +5,14 @@ import (
 	"sort"
 )
 
-// Less compares byte chunks.
-type Less func(a, b []byte) bool
+// Compares byte chunks. -1 for a < b and 0 for a == b.
+type Compare func(a, b []byte) int
 
 // Equal compares two byte chunks for equality.
 type Equal func(a, b []byte) bool
 
-func stdLess(a, b []byte) bool {
-	return bytes.Compare(a, b) < 0
+func stdCompare(a, b []byte) int {
+	return bytes.Compare(a, b)
 }
 
 // Options contains sorting options
@@ -21,9 +21,9 @@ type Options struct {
 	// By default os.TempDir() is used.
 	WorkDir string
 
-	// Less defines the compare function.
-	// Default: bytes.Compare() < 0
-	Less Less
+	// Compare defines the compare function.
+	// Default: bytes.Compare
+	Compare Compare
 
 	// Sort defines the sort function that is used.
 	// Default: sort.Sort
@@ -31,6 +31,7 @@ type Options struct {
 
 	// Dedupe defines the compare function for de-duplication.
 	// Default: nil (= do not de-dupe)
+	// Keeps the last added item.
 	Dedupe Equal
 
 	// BufferSize limits the memory buffer used for sorting.
@@ -47,8 +48,8 @@ func (o *Options) norm() *Options {
 		opt = *o
 	}
 
-	if opt.Less == nil {
-		opt.Less = stdLess
+	if opt.Compare == nil {
+		opt.Compare = stdCompare
 	}
 
 	if opt.Sort == nil {

--- a/tempfile.go
+++ b/tempfile.go
@@ -60,7 +60,7 @@ func (t *tempWriter) Flush() error {
 		return err
 	}
 
-	pos, err := t.f.Seek(0, os.SEEK_CUR)
+	pos, err := t.f.Seek(0, io.SeekCurrent)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Make it deterministic that the last added item is kept on duplicate values.
When using extsort as part of a db like system, usually the last item (updates) is most important.